### PR TITLE
Support for customized origin compat heat resistance power

### DIFF
--- a/src/main/java/com/stereowalker/survive/compat/OriginsCompat.java
+++ b/src/main/java/com/stereowalker/survive/compat/OriginsCompat.java
@@ -7,14 +7,19 @@ import io.github.apace100.origins.integration.OriginEventsArchitectury;
 import io.github.apace100.origins.origin.Origin;
 import io.github.apace100.origins.power.PowerTypeRegistry;
 
+import com.stereowalker.survive.config.Config;
+
 public class OriginsCompat {
 	public static void initOriginsPatcher() {
 		OriginEventsArchitectury.ORIGIN_LOADING.register(OriginsCompat::modifyOrigins);
 	}
 
 	public static void modifyOrigins(Origin origin) {
-		if (origin.getIdentifier().equals(Origins.identifier("blazeborn"))) {
-			origin.add(PowerTypeRegistry.get(Survive.getInstance().location("heat_resistance")));
+		String[] origin_idents = Config.originsHeat.split(",");
+		for (String id : origin_idents) {
+			if (origin.getIdentifier().toString().equals(id)) {
+				origin.add(PowerTypeRegistry.get(Survive.getInstance().location("heat_resistance")));
+			}
 		}
 	}
 }

--- a/src/main/java/com/stereowalker/survive/config/Config.java
+++ b/src/main/java/com/stereowalker/survive/config/Config.java
@@ -199,4 +199,10 @@ public class Config {
 			"A lot of the mechanics in this mod become a lot more unreasonable without enchantments"})
 	public static boolean disable_enchantments = false;
 
+	//
+	//Other mods
+	@UnionConfig.Entry(group = "Other" , name = "Origins Heat Resistant Races", type = Type.COMMON)
+	@UnionConfig.Comment(comment = {"If you have the origins mod, specify the names of races to add heat resistance to. Comma separated list"})
+	public static String originsHeat = "blazeborn";
+
 }

--- a/src/main/java/com/stereowalker/survive/config/Config.java
+++ b/src/main/java/com/stereowalker/survive/config/Config.java
@@ -203,6 +203,6 @@ public class Config {
 	//Other mods
 	@UnionConfig.Entry(group = "Other" , name = "Origins Heat Resistant Races", type = Type.COMMON)
 	@UnionConfig.Comment(comment = {"If you have the origins mod, specify the names of races to add heat resistance to. Comma separated list"})
-	public static String originsHeat = "blazeborn";
+	public static String originsHeat = "origins:blazeborn";
 
 }


### PR DESCRIPTION
I wanted to add support for any potential custom origins made for the origins mod. Before it was hardcoded as blazeborn only, now it reads a comma separated list from the config file.

Really glad this mod exists, thanks!