### PR TITLE
Fixed server-crashing bug

### DIFF
--- a/src/main/java/com/stereowalker/survive/core/SurviveEntityStats.java
+++ b/src/main/java/com/stereowalker/survive/core/SurviveEntityStats.java
@@ -31,7 +31,6 @@ public class SurviveEntityStats {
 		if(entity != null) {
 			if (getModNBT(entity) != null && getModNBT(entity).contains(waterStatsID, 10)) {
 				stats.read(getModNBT(entity).getCompound(waterStatsID));
-				return stats;
 			}
 		}
 		return stats;
@@ -44,7 +43,6 @@ public class SurviveEntityStats {
 			if(entity != null) {
 				if (getModNBT(entity) != null && getModNBT(entity).contains(energyStatsID, 10)) {
 					stats.read(getModNBT(entity).getCompound(energyStatsID));
-					return stats;
 				}
 			}
 			return stats;
@@ -58,7 +56,6 @@ public class SurviveEntityStats {
 		if(entity != null) {
 			if (getModNBT(entity) != null && getModNBT(entity).contains(temperatureStatsID, 10)) {
 				stats.read(getModNBT(entity).getCompound(temperatureStatsID));
-				return stats;
 			}
 		}
 		return stats;
@@ -69,7 +66,6 @@ public class SurviveEntityStats {
 		if(entity != null) {
 			if (getModNBT(entity) != null && getModNBT(entity).contains(hygieneStatsID, 10)) {
 				stats.read(getModNBT(entity).getCompound(hygieneStatsID));
-				return stats;
 			}
 		}
 		return stats;
@@ -80,7 +76,6 @@ public class SurviveEntityStats {
 		if(entity != null) {
 			if (getModNBT(entity) != null && getModNBT(entity).contains(nutritionStatsID, 10)) {
 				stats.read(getModNBT(entity).getCompound(nutritionStatsID));
-				return stats;
 			}
 		}
 		return stats;
@@ -91,7 +86,6 @@ public class SurviveEntityStats {
 		if(entity != null) {
 			if (getModNBT(entity) != null && getModNBT(entity).contains(wellbeingStatsID, 10)) {
 				stats.read(getModNBT(entity).getCompound(wellbeingStatsID));
-				return stats;
 			}
 		}
 		return stats;
@@ -102,7 +96,6 @@ public class SurviveEntityStats {
 		if(entity != null) {
 			if (getModNBT(entity) != null && getModNBT(entity).contains(sleepStatsID, 10)) {
 				stats.read(getModNBT(entity).getCompound(sleepStatsID));
-				return stats;
 			}
 		}
 		return stats;

--- a/src/main/java/com/stereowalker/survive/core/SurviveEntityStats.java
+++ b/src/main/java/com/stereowalker/survive/core/SurviveEntityStats.java
@@ -38,14 +38,19 @@ public class SurviveEntityStats {
 	}
 	
 	public static StaminaData getEnergyStats(LivingEntity entity) {
-		StaminaData stats = new StaminaData(entity.getAttributeValue(SAttributes.MAX_STAMINA));
-		if(entity != null) {
-			if (getModNBT(entity) != null && getModNBT(entity).contains(energyStatsID, 10)) {
-				stats.read(getModNBT(entity).getCompound(energyStatsID));
-				return stats;
+		try {
+			double max_stamina = entity.getAttributeValue(SAttributes.MAX_STAMINA);
+			StaminaData stats = new StaminaData(max_stamina);
+			if(entity != null) {
+				if (getModNBT(entity) != null && getModNBT(entity).contains(energyStatsID, 10)) {
+					stats.read(getModNBT(entity).getCompound(energyStatsID));
+					return stats;
+				}
 			}
+			return stats;
+		} catch (IllegalArgumentException e) {
+			return null;
 		}
-		return stats;
 	}
 	
 	public static TemperatureData getTemperatureStats(LivingEntity entity) {

--- a/src/main/java/com/stereowalker/survive/world/effect/UnwellMobEffect.java
+++ b/src/main/java/com/stereowalker/survive/world/effect/UnwellMobEffect.java
@@ -21,19 +21,21 @@ public class UnwellMobEffect extends MobEffect {
 
 	@Override
 	public void applyEffectTick(LivingEntity entityLivingBaseIn, int amplifier) {
-		StaminaData energyStats = SurviveEntityStats.getEnergyStats(entityLivingBaseIn);
-		if (this == SMobEffects.HYPOTHERMIA && entityLivingBaseIn instanceof Player) {
-			if (entityLivingBaseIn.getHealth() > entityLivingBaseIn.getMaxHealth()/3.5F)
-				entityLivingBaseIn.hurt(SDamageSource.HYPOTHERMIA, 0.8F);
-			if ((float)energyStats.getEnergyLevel() > ((float)energyStats.getEnergyLevel())*0.3)
-				energyStats.addExhaustion((Player) entityLivingBaseIn, (1.0F * (float)(amplifier + 1)), "Hypothermia effect");
-		} else if (this == SMobEffects.HYPERTHERMIA && entityLivingBaseIn instanceof Player) {
-			if (entityLivingBaseIn.getHealth() > entityLivingBaseIn.getMaxHealth()/3.5F)
-				entityLivingBaseIn.hurt(SDamageSource.HYPERTHERMIA, 0.8F);
-			if ((float)energyStats.getEnergyLevel() > ((float)energyStats.getEnergyLevel())*0.3)
-				energyStats.addExhaustion((Player) entityLivingBaseIn, (1.0F * (float)(amplifier + 1)), "Hyperthermia effect");
+		if (entityLivingBaseIn instanceof Player) {
+			StaminaData energyStats = SurviveEntityStats.getEnergyStats(entityLivingBaseIn);
+			if (this == SMobEffects.HYPOTHERMIA) {
+				if (entityLivingBaseIn.getHealth() > entityLivingBaseIn.getMaxHealth() / 3.5F)
+					entityLivingBaseIn.hurt(SDamageSource.HYPOTHERMIA, 0.8F);
+				if ((float) energyStats.getEnergyLevel() > ((float) energyStats.getEnergyLevel()) * 0.3)
+					energyStats.addExhaustion((Player) entityLivingBaseIn, (1.0F * (float) (amplifier + 1)), "Hypothermia effect");
+			} else if (this == SMobEffects.HYPERTHERMIA) {
+				if (entityLivingBaseIn.getHealth() > entityLivingBaseIn.getMaxHealth() / 3.5F)
+					entityLivingBaseIn.hurt(SDamageSource.HYPERTHERMIA, 0.8F);
+				if ((float) energyStats.getEnergyLevel() > ((float) energyStats.getEnergyLevel()) * 0.3)
+					energyStats.addExhaustion((Player) entityLivingBaseIn, (1.0F * (float) (amplifier + 1)), "Hyperthermia effect");
+			}
+			energyStats.save(entityLivingBaseIn);
 		}
-		energyStats.save(entityLivingBaseIn);
 		super.applyEffectTick(entityLivingBaseIn, amplifier);
 	}
 


### PR DESCRIPTION
My friend was playing on a modded server and her sword got the ability to give mobs hydration or something, which led to stomachaches or something. Regardless, at some point, the code tried to access the `MAX_STAMINA` attribute for the mob affected. Mobs do not have that attribute, so there was an exception, and the server crashed. 

I modified the code so that it only tries to get the `MAX_STAMINA` after confirming the affected entity is a player.

(Also did a tiny bit of code cleanup while I was in that file)